### PR TITLE
use File::Slurper optionally instead of File::Slurp::Tiny

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -70,7 +70,7 @@ WriteMakefile1(
                 requires   => {%RUN_DEPS},
                 recommends => {
                     'ExtUtils::CBuilder' => '0.280220',
-                    'File::Slurp::Tiny'  => 0,
+                    'File::Slurper'      => 0,
                     'Scalar::Util'       => '1.18',
                 },
             },

--- a/lib/Config/AutoConf.pm
+++ b/lib/Config/AutoConf.pm
@@ -47,8 +47,8 @@ sub looks_like_number {
 }
 EOP
 
-eval "use File::Slurp::Tiny qw/read_file/;";
-__PACKAGE__->can("read_file") or eval <<'EOP';
+eval "use File::Slurper qw/read_binary/;";
+__PACKAGE__->can("read_binary") or eval <<'EOP';
 =begin private
 
 =head2 read_file
@@ -57,7 +57,7 @@ __PACKAGE__->can("read_file") or eval <<'EOP';
 
 =cut
 
-sub read_file {
+sub read_binary {
   my $fn = shift;
   local $@ = "";
   open( my $fh, "<", $fn ) or croak "Error opening $fn: $!";
@@ -499,7 +499,7 @@ EOLEX
         );
         defined $self->{lex}->{root} or $self->{lex}->{root} = $lex_root_var;
 
-        my $conftest = read_file($lex_root_var . ".c");
+        my $conftest = read_binary($lex_root_var . ".c");
         unlink $lex_root_var . ".c";
 
         $cache_name = $self->_cache_name("lib", "lex");


### PR DESCRIPTION
File::Slurper is recommended over File::Slurp::Tiny because File::Slurp::Tiny inherits the interface issues of File::Slurp; namely that read_file can take either a filename or filehandle. Here it is only used on a filename, so read_binary should work fine.